### PR TITLE
Rely on interface for monitoring check logic

### DIFF
--- a/ldapwatch.go
+++ b/ldapwatch.go
@@ -14,22 +14,22 @@ type Searcher interface {
 	Search(sr *ldap.SearchRequest) (*ldap.SearchResult, error)
 }
 
-// Monitor ...
-type Monitor interface {
+// Checker ...
+type Checker interface {
 	Check(Result)
 }
 
-// NullMonitor ...
-type NullMonitor struct{}
+// NullChecker ...
+type NullChecker struct{}
 
 // Check ...
-func (m *NullMonitor) Check(Result) {}
+func (m *NullChecker) Check(Result) {}
 
 // Watch ...
 type Watch struct {
 	state         int
 	searchRequest *ldap.SearchRequest
-	monitor       Monitor
+	monitor       Checker
 }
 
 // Result ...
@@ -104,7 +104,7 @@ func (w *Watcher) Stop() {
 }
 
 // Add ...
-func (w *Watcher) Add(sr *ldap.SearchRequest, m Monitor) error {
+func (w *Watcher) Add(sr *ldap.SearchRequest, m Checker) error {
 	watch := Watch{state: 0, searchRequest: sr, monitor: m}
 	w.watches = append(w.watches, &watch)
 	return nil

--- a/ldapwatch_test.go
+++ b/ldapwatch_test.go
@@ -126,12 +126,12 @@ func dupEntry(c *ldap.Conn, existingRdn string) error {
 	return c.Add(ar)
 }
 
-type testMonitor struct {
+type testChecker struct {
 	prev    Result
 	Changed bool
 }
 
-func (m *testMonitor) Check(r Result) {
+func (m *testChecker) Check(r Result) {
 	// no previous results (initial search)
 	if (Result{}) == m.prev {
 		m.prev = r
@@ -203,7 +203,7 @@ func TestWatchPerson(t *testing.T) {
 			t.Fatalf("NewWatcher: %s", err)
 		}
 
-		mon := &testMonitor{}
+		mon := &testChecker{}
 
 		err = watcher.Add(searchRequest, mon)
 		if err != nil {
@@ -232,7 +232,7 @@ func TestWatchPerson(t *testing.T) {
 			t.Fatalf("NewWatcher: %s", err)
 		}
 
-		mon := &testMonitor{}
+		mon := &testChecker{}
 		err = watcher.Add(searchRequest, mon)
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Replaces complicated comparison function and result channel arguments (`func compare(Result, Result) bool` and `chan Result`) for adding a search request to watch with a simpler interface that calls `Check(Result)`.

This pushes the state handling and notification logic to the `Check`-implementing type.

A `NullChecker`, which does nothing, is provided. I anticipate implementing a suite of basic checks.

~~Currently the interface is called `Monitor`, as it is responsible for monitoring for changes. However, it implements `Check(Result)` and could very well be called `ldapwatch.Checker` (I hear that's an idiomatic name).~~ Decided to go with `ldapwatch.Checker` as the interface name.
