### PR TITLE
Worker-per-watcher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM golang:1.9
 WORKDIR /go/src/ldapwatch
 COPY . .
 
+# we don't need to build the examples
+RUN rm -rf ./examples
+
 RUN go get -d -v ./...
 RUN go install -v ./...
 

--- a/examples/user_modified/main.go
+++ b/examples/user_modified/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/mtodd/ldapwatch"
+
+	ldap "gopkg.in/ldap.v2"
+)
+
+// Implements the ldapwatch.Checker interface in order to check whether
+// the search results change over time.
+//
+// In this case, our Checker keeps track of previous results as well as
+// holding a channel that we notify whenever changes are detected.
+type myChecker struct {
+	prev ldapwatch.Result
+	c    chan ldapwatch.Result
+}
+
+// Check receives the result of the search; the Checker needs to take action
+// if the result does not match what it expects.
+func (c *myChecker) Check(r ldapwatch.Result) {
+	if r.Err != nil {
+		log.Printf("%s", r.Err)
+		return
+	}
+
+	// first search sets baseline
+	if (ldapwatch.Result{}) == c.prev {
+		c.prev = r
+		return
+	}
+
+	if len(c.prev.Results.Entries) != len(r.Results.Entries) {
+		// entries returned does not match
+		c.prev = r
+		c.c <- r
+		return
+	}
+
+	prevEntry := c.prev.Results.Entries[0]
+	nextEntry := r.Results.Entries[0]
+
+	if prevEntry.GetAttributeValue("modifyTimestamp") != nextEntry.GetAttributeValue("modifyTimestamp") {
+		// modifyTimestamp changed
+		c.prev = r
+		c.c <- r
+		return
+	}
+
+	// no change
+}
+
+func main() {
+	conn, _ := ldap.Dial("tcp", "localhost:389")
+	defer conn.Close()
+	conn.Bind("cn=admin,dc=planetexpress,dc=com", "GoodNewsEveryone")
+
+	updates := make(chan ldapwatch.Result)
+	done := make(chan struct{})
+	defer func() { close(done) }()
+	go func(c chan ldapwatch.Result, done chan struct{}) {
+		for {
+			select {
+			case result := <-c:
+				// result is the search results that have changed
+				log.Println("change detected")
+				log.Printf("%#v", result)
+			case <-done:
+				return
+			}
+		}
+	}(updates, done)
+
+	w, err := ldapwatch.NewWatcher(conn, 1*time.Second, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer w.Stop()
+
+	c := myChecker{
+		c: updates,
+	}
+
+	// Search to monitor for changes
+	searchRequest := ldap.NewSearchRequest(
+		"ou=people,dc=planetexpress,dc=com",
+		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+		"(cn=Philip J. Fry)",
+		[]string{"*", "modifyTimestamp"},
+		nil,
+	)
+
+	// register the search
+	w.Add(searchRequest, &c)
+
+	// run until SIGINT is triggered
+	term := make(chan os.Signal, 1)
+	signal.Notify(term, os.Interrupt)
+
+	w.Start()
+
+	<-term
+}

--- a/examples/user_modified/main.go
+++ b/examples/user_modified/main.go
@@ -68,7 +68,7 @@ func main() {
 			select {
 			case result := <-c:
 				// result is the search results that have changed
-				log.Println("change detected")
+				log.Printf("change detected: %s", result.Results.Entries[0].DN)
 				log.Printf("%#v", result)
 			case <-done:
 				return

--- a/ldapwatch.go
+++ b/ldapwatch.go
@@ -25,15 +25,6 @@ type NullChecker struct{}
 // Check ...
 func (m *NullChecker) Check(Result) {}
 
-// Watch ...
-type Watch struct {
-	watcher       *Watcher
-	searchRequest *ldap.SearchRequest
-	checker       Checker
-	tick          chan struct{}
-	done          chan struct{}
-}
-
 // Result ...
 type Result struct {
 	Watch   *Watch
@@ -53,7 +44,7 @@ type Watcher struct {
 
 const defaultDuration = 500 * time.Millisecond
 
-// NewWatcher ...
+// NewWatcher constructs a Watcher.
 func NewWatcher(conn Searcher, dur time.Duration, logger *log.Logger) (*Watcher, error) {
 	if dur == 0 {
 		dur = defaultDuration
@@ -67,7 +58,7 @@ func NewWatcher(conn Searcher, dur time.Duration, logger *log.Logger) (*Watcher,
 		conn:     conn,
 		duration: dur,
 		logger:   logger,
-		watches:  make([]*Watch, 0, 10),
+		watches:  make([]*Watch, 0),
 	}
 
 	return w, nil
@@ -110,7 +101,16 @@ func (w *Watcher) Stop() {
 	w.wg.Wait()
 }
 
-// Add ...
+// Watch ...
+type Watch struct {
+	watcher       *Watcher
+	searchRequest *ldap.SearchRequest
+	checker       Checker
+	tick          chan struct{}
+	done          chan struct{}
+}
+
+// Add instructs the Watcher to periodically check the given search request.
 func (w *Watcher) Add(sr *ldap.SearchRequest, c Checker) (Watch, error) {
 	watch := Watch{
 		watcher:       w,

--- a/ldapwatch.go
+++ b/ldapwatch.go
@@ -27,7 +27,6 @@ func (m *NullChecker) Check(Result) {}
 
 // Watch ...
 type Watch struct {
-	state         int
 	watcher       *Watcher
 	searchRequest *ldap.SearchRequest
 	checker       Checker
@@ -114,7 +113,6 @@ func (w *Watcher) Stop() {
 // Add ...
 func (w *Watcher) Add(sr *ldap.SearchRequest, c Checker) (Watch, error) {
 	watch := Watch{
-		state:         0,
 		watcher:       w,
 		searchRequest: sr,
 		checker:       c,

--- a/ldapwatch.go
+++ b/ldapwatch.go
@@ -48,12 +48,18 @@ type Watcher struct {
 }
 
 // NewWatcher ...
-func NewWatcher(conn Searcher) (*Watcher, error) {
-	logger := log.New(os.Stdout, "", log.LstdFlags)
+func NewWatcher(conn Searcher, dur time.Duration, logger *log.Logger) (*Watcher, error) {
+	if dur == 0 {
+		dur = 500 * time.Millisecond
+	}
+
+	if logger == nil {
+		logger = log.New(os.Stdout, "", log.LstdFlags)
+	}
 
 	w := &Watcher{
 		conn:     conn,
-		duration: 500 * time.Millisecond,
+		duration: dur,
 		logger:   logger,
 		watches:  make([]*Watch, 0, 10),
 	}

--- a/ldapwatch.go
+++ b/ldapwatch.go
@@ -42,7 +42,7 @@ type Result struct {
 	Err     error
 }
 
-// Watcher watches a set of LDAP nodes, delivering events to a channel.
+// Watcher coordinates Watch workers.
 type Watcher struct {
 	conn     Searcher
 	logger   *log.Logger
@@ -52,10 +52,12 @@ type Watcher struct {
 	wg       sync.WaitGroup
 }
 
+const defaultDuration = 500 * time.Millisecond
+
 // NewWatcher ...
 func NewWatcher(conn Searcher, dur time.Duration, logger *log.Logger) (*Watcher, error) {
 	if dur == 0 {
-		dur = 500 * time.Millisecond
+		dur = defaultDuration
 	}
 
 	if logger == nil {

--- a/ldapwatch_test.go
+++ b/ldapwatch_test.go
@@ -231,14 +231,14 @@ func TestWatchPerson(t *testing.T) {
 		}
 
 		// first run, nothing expected
-		watch.Tick()
+		watch.tick()
 
 		if mon.Changed {
 			t.Fatalf("entry was marked as updated on the first round")
 		}
 
 		// second run, nothing expected
-		watch.Tick()
+		watch.tick()
 
 		if mon.Changed {
 			t.Fatalf("entry was marked as updated but should've been unchanged")
@@ -259,7 +259,7 @@ func TestWatchPerson(t *testing.T) {
 		}
 
 		// first run, nothing expected
-		watch.Tick()
+		watch.tick()
 
 		if mon.Changed {
 			t.Fatalf("entry was marked as updated on the first round")
@@ -278,7 +278,7 @@ func TestWatchPerson(t *testing.T) {
 		}
 
 		// second run, nothing expected
-		watch.Tick()
+		watch.tick()
 
 		time.Sleep(100 * time.Millisecond)
 

--- a/ldapwatch_test.go
+++ b/ldapwatch_test.go
@@ -3,7 +3,6 @@ package ldapwatch
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -205,20 +204,20 @@ func TestWatchPerson(t *testing.T) {
 
 		mon := &testChecker{}
 
-		err = watcher.Add(searchRequest, mon)
+		watch, err := watcher.Add(searchRequest, mon)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatalf("Add: %s", err)
 		}
 
 		// first run, nothing expected
-		tick(watcher)
+		watch.Tick()
 
 		if mon.Changed {
 			t.Fatalf("entry was marked as updated on the first round")
 		}
 
 		// second run, nothing expected
-		tick(watcher)
+		watch.Tick()
 
 		if mon.Changed {
 			t.Fatalf("entry was marked as updated but should've been unchanged")
@@ -233,13 +232,13 @@ func TestWatchPerson(t *testing.T) {
 		}
 
 		mon := &testChecker{}
-		err = watcher.Add(searchRequest, mon)
+		watch, err := watcher.Add(searchRequest, mon)
 		if err != nil {
-			log.Fatal(err)
+			t.Fatalf("Add: %s", err)
 		}
 
 		// first run, nothing expected
-		tick(watcher)
+		watch.Tick()
 
 		if mon.Changed {
 			t.Fatalf("entry was marked as updated on the first round")
@@ -258,7 +257,7 @@ func TestWatchPerson(t *testing.T) {
 		}
 
 		// second run, nothing expected
-		tick(watcher)
+		watch.Tick()
 
 		time.Sleep(100 * time.Millisecond)
 

--- a/ldapwatch_test.go
+++ b/ldapwatch_test.go
@@ -198,7 +198,7 @@ func TestWatchPerson(t *testing.T) {
 	)
 
 	t.Run("unmodified", func(t *testing.T) {
-		watcher, err := NewWatcher(conn)
+		watcher, err := NewWatcher(conn, 500*time.Millisecond, nil)
 		if err != nil {
 			t.Fatalf("NewWatcher: %s", err)
 		}
@@ -227,7 +227,7 @@ func TestWatchPerson(t *testing.T) {
 
 	// kill the update gofunc
 	t.Run("modified", func(t *testing.T) {
-		watcher, err := NewWatcher(conn)
+		watcher, err := NewWatcher(conn, 500*time.Millisecond, nil)
 		if err != nil {
 			t.Fatalf("NewWatcher: %s", err)
 		}

--- a/ldapwatch_test.go
+++ b/ldapwatch_test.go
@@ -56,6 +56,27 @@ func TestEnv(t *testing.T) {
 	}
 }
 
+type fakeSearcher struct{}
+
+func (fs fakeSearcher) Search(sr *ldap.SearchRequest) (*ldap.SearchResult, error) {
+	return nil, nil
+}
+
+func TestNewWatcher(t *testing.T) {
+	t.Run("defaults", func(t *testing.T) {
+		var dur time.Duration
+		w, _ := NewWatcher(fakeSearcher{}, dur, nil)
+
+		if w.duration != defaultDuration {
+			t.Fatalf("default duration (%#v) expected but got %#v", defaultDuration, w.duration)
+		}
+
+		if w.logger == nil {
+			t.Fatalf("default logger expected but got %#v", w.logger)
+		}
+	})
+}
+
 func findEntry(c *ldap.Conn, cn string) (*ldap.Entry, error) {
 	sr := ldap.NewSearchRequest(
 		base,


### PR DESCRIPTION
This PR moves towards starting a worker goroutine per watch.

I'm not thrilled with the way we have to fanout the tick from the Ticker to the worker goroutines. Each worker should manage its own sleep with their own `time.Ticker`, or via [`time.After`](https://golang.org/pkg/time/#After) (or a [`time.Timer`](https://golang.org/pkg/time/#Timer)) to allow it to diverge from the other searches (considering some searches will take longer than the configured ticker duration).

Also adds an example implementation (one that I can actually run to test with). It's currently making the build fail. I'll replace the (broken) sample usage in the README with a link and instead describe step-by-step usage.
