### PR TITLE
Check (ldap.SearchResults, error) without an ldapwatch.Result intermediary

### DIFF
--- a/ldapwatch.go
+++ b/ldapwatch.go
@@ -16,21 +16,14 @@ type Searcher interface {
 
 // Checker ...
 type Checker interface {
-	Check(Result)
+	Check(*ldap.SearchResult, error)
 }
 
 // NullChecker ...
 type NullChecker struct{}
 
 // Check ...
-func (m *NullChecker) Check(Result) {}
-
-// Result ...
-type Result struct {
-	Watch   *Watch
-	Results *ldap.SearchResult
-	Err     error
-}
+func (m *NullChecker) Check(*ldap.SearchResult, error) {}
 
 // Watcher coordinates Watch workers.
 type Watcher struct {
@@ -128,19 +121,8 @@ func (w *Watch) stop() {
 }
 
 // perform the search and check the results with the Checker
-func (w *Watch) tick() error {
-	var result Result
-	sr, err := w.search()
-
-	if err != nil {
-		result = Result{Watch: w, Err: err}
-	} else {
-		result = Result{Watch: w, Results: sr}
-	}
-
-	w.checker.Check(result)
-
-	return nil
+func (w *Watch) tick() {
+	w.checker.Check(w.search())
 }
 
 // perform search via the Searcher

--- a/ldapwatch_test.go
+++ b/ldapwatch_test.go
@@ -147,26 +147,26 @@ func dupEntry(c *ldap.Conn, existingRdn string) error {
 }
 
 type testChecker struct {
-	prev    Result
+	prev    *ldap.SearchResult
 	Changed bool
 }
 
-func (m *testChecker) Check(r Result) {
+func (m *testChecker) Check(r *ldap.SearchResult, err error) {
 	// no previous results (initial search)
-	if (Result{}) == m.prev {
+	if m.prev == nil {
 		m.prev = r
 		return
 	}
 
 	// check length differences
-	if len(m.prev.Results.Entries) != len(r.Results.Entries) {
+	if len(m.prev.Entries) != len(r.Entries) {
 		m.Changed = true
 		return
 	}
 
 	// check DNs match
-	prevE := m.prev.Results.Entries[0]
-	nextE := r.Results.Entries[0]
+	prevE := m.prev.Entries[0]
+	nextE := r.Entries[0]
 	if prevE.DN != nextE.DN {
 		m.Changed = true
 		return


### PR DESCRIPTION
This PR updates the `ldapwatch.Checker` interface to take the `*ldap.SearchResult` and `error` returned by the `ldapwatch.Searcher`'s `Search()` method (which is usually just [`ldap.Conn.Search()`](https://godoc.org/gopkg.in/ldap.v2#Conn.Search)).

This helps remove a lot of unnecessary field diving (e.g. `result.Results.Entries[0]` to `r.Entries[0]`) and code (`ldapwatch.Result` specifically) in the first place).

A nice side-effect is that, for `ldapwatch.Checker` implementations that track the previous search results (pretty much any that will want to check the search results against the previously found results, i.e. 95% of them), `*ldap.SearchResult` can be `nil` (which is so much easier than checking against the zero value of `ldapwatch.Result`).
